### PR TITLE
Add server-mongo container

### DIFF
--- a/server-mongo/Dockerfile
+++ b/server-mongo/Dockerfile
@@ -1,0 +1,8 @@
+FROM jboss/keycloak:1.2.0.Beta1
+
+USER root
+WORKDIR /opt/jboss
+
+ADD changeDatabase.jq /opt/jboss/keycloak/
+
+RUN yum install -y jq && cat keycloak/standalone/configuration/keycloak-server.json | jq -f keycloak/changeDatabase.jq > keycloak/standalone/configuration/keycloak-server.json

--- a/server-mongo/README.md
+++ b/server-mongo/README.md
@@ -1,0 +1,28 @@
+# Keycloak MongoDB
+
+Extends the Keycloak docker image to use MongoDB
+
+## Usage
+
+### Start a MongoDB instance
+
+First start a MongoDB instance using the MongoDB docker image:
+
+    docker run --name mongo -e MONGODB_DBNAME=keycloak -d mongo
+
+### Start a Keycloak instance
+
+Start a Keycloak instance and connect to the MongoDB instance:
+
+    docker run --name keycloak -e MONGODB_HOST=mongo jboss/keycloak-mongo
+
+### Environment variables
+
+When starting the Keycloak instance you can pass a number of environment variables to configure how it connects to MongoDB. For example:
+
+    docker run --name keycloak --link mongo:mongo -e MONGODB_DBNAME=keycloak -d jboss/keycloak-mongo
+
+#### MONGODB_DBNAME
+
+Specify name of MongoDB database (optional, default is `keycloak`).
+

--- a/server-mongo/changeDatabase.jq
+++ b/server-mongo/changeDatabase.jq
@@ -1,0 +1,11 @@
+.eventsStore.provider |= "mongo" | 
+  .eventsStore.mongo["exclude-events"] |= ["REFRESH_TOKEN"] | 
+  .realm.provider = "mongo" | 
+  .user.provider = "mongo" | 
+  .connectionsMongo.default.host = "${env.MONGODB_HOST:127.0.0.1}" |
+  .connectionsMongo.default.port = "${env.MONGODB_PORT:27017}" |
+  .connectionsMongo.default.db = "${env.MONGODB_DBNAME:keycloak}" |
+  .connectionsMongo.default.connectionsPerHost = 100 |
+  .connectionsMongo.default.databaseSchema = "update" |
+  del (.eventsStore.jpa) | 
+  del (.connectionsJpa)


### PR DESCRIPTION
Builds a container that uses a [MongoDB](https://www.mongodb.org/) backend for Keycloak server.

The `Dockerfile` runs `yum install` to get the [command-line JSON parser jq](http://stedolan.github.io/jq/) which is used to manipulate the `keycloak-server.json` file.